### PR TITLE
fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,6 @@ Then, install it using maven:
 Or run using:
 
 ```bash
-./mvnw springboot:run
+./mvnw spring-boot:run
 ```
 


### PR DESCRIPTION
The command mvn springboot:run results in "No plugin found for prefix 'springboot'". Correct syntax is 'spring-boot:run'.